### PR TITLE
test(health): moves and renames healthcheck.spec.ts to get.test.ts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
   ],
   collectCoverageFrom: [
     "src/**/*.{js,ts}",
+    "src/*.{js,ts}"
   ],
   reporters: ["default", "jest-junit"],
   testEnvironment: 'node'

--- a/src/routes/health/get.test.ts
+++ b/src/routes/health/get.test.ts
@@ -1,8 +1,8 @@
-import { getHealthCheck } from './routes/health/get'
-import { Environment } from './utils/Environment'
-import { createSpyObj } from './test/helper/jest'
+import { getHealthCheck } from './get'
+import { Environment } from '../../utils/Environment'
+import { createSpyObj } from '../../test/helper/jest'
 
-describe('Healthcheck', () => {
+describe('Checks health of dependent services', () => {
   let resSpy
   let req
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe('Healthcheck', () => {
     resSpy.status.mockReturnThis()
     resSpy.json.mockReturnThis()
   })
-  it('should be healthy', async () => {
+  it('should be healthy when database is ready and vault is unsealed', async () => {
     Environment.Config = { db_provider: 'POSTGRES' } as any
 
     req.mpsService.secrets.health.mockReturnValue({ initialized: true, sealed: false })
@@ -76,7 +76,7 @@ describe('Healthcheck', () => {
     // })
     expect(resSpy.status).toHaveBeenCalledWith(503)
   })
-  it('should not be healthy when vault sealed', async () => {
+  it('should not be healthy when vault is not ready', async () => {
     req.mpsService.secrets.health.mockRejectedValue({ error: { code: 'ECONNREFUSED' } })
     await getHealthCheck(req, resSpy)
     // expect(resSpy.json).toHaveBeenCalledWith({


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?
Moves and renames healthcheck.spec.ts to get.test.ts.  Previous healthcheck.spec.ts name implied it was tied to healthcheck.ts under src.


## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )
