### PR TITLE
fix(ws): clear kvmConnect when even if caused exceptionally closed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "node-forge": "^1.3.1",
         "pg": "^8.7.3",
         "rc": "^1.2.8",
+        "uuid": "^8.3.2",
         "winston": "^3.7.2",
         "ws": "^8.7.0",
         "xml2js": "^0.4.23"
@@ -33,6 +34,7 @@
         "@types/node": "^16.11.15",
         "@types/node-forge": "^1.0.2",
         "@types/pg": "^8.6.5",
+        "@types/uuid": "^8.3.4",
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
@@ -1590,6 +1592,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -5164,15 +5172,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/jest-junit/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz",
@@ -7899,6 +7898,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -9474,6 +9481,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/ws": {
@@ -12104,14 +12117,6 @@
         "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2",
         "xml": "^1.0.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
-        }
       }
     },
     "jest-leak-detector": {
@@ -14140,6 +14145,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "node-forge": "^1.3.1",
     "pg": "^8.7.3",
     "rc": "^1.2.8",
+    "uuid": "^8.3.2",
     "winston": "^3.7.2",
     "ws": "^8.7.0",
     "xml2js": "^0.4.23"
@@ -57,6 +58,7 @@
     "@types/node": "^16.11.15",
     "@types/node-forge": "^1.0.2",
     "@types/pg": "^8.6.5",
+    "@types/uuid": "^8.3.4",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/src/amt/ConnectedDevice.ts
+++ b/src/amt/ConnectedDevice.ts
@@ -9,11 +9,11 @@ import { HttpHandler } from './HttpHandler'
 export class ConnectedDevice {
   httpHandler: HttpHandler
   ciraSocket: CIRASocket
-  kvmConnect: boolean
+  kvmConnect: string | null // Session ID
 
   constructor (ciraSocket: CIRASocket, readonly username: string, readonly password: string) {
     this.ciraSocket = ciraSocket
     this.httpHandler = new HttpHandler()
-    this.kvmConnect = false
+    this.kvmConnect = null
   }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [X] Unit Tests have been added for new changes
- [X] API tests have been updated if applicable
- [X] All commented code has been removed
- [X] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?

Currently, If the relay WebSocket is disconnected before starting the relay, kvm is no longer available before killing MPS or resetting CIRA connection.

So, by giving a SessionID to the WebSocket connection, clear kvmConnect when the connection is disconnected.