### PR TITLE
fix: issue 668 - ensure CIM_KVMRedirectionSAP is present before using it

### DIFF
--- a/src/routes/amt/getAMTFeatures.ts
+++ b/src/routes/amt/getAMTFeatures.ts
@@ -46,6 +46,7 @@ export function processAmtRedirectionResponse (amtRedirection: AMT.Models.Redire
 }
 
 export function processKvmRedirectionResponse (kvmRedirection: CIM.Models.KVMRedirectionSAP): boolean {
+  if (kvmRedirection == null) return false
   const kvm = (kvmRedirection.EnabledState === Common.Models.CIM_KVM_REDIRECTION_SAP_ENABLED_STATE.Enabled ||
                kvmRedirection.EnabledState === Common.Models.CIM_KVM_REDIRECTION_SAP_ENABLED_STATE.EnabledButOffline)
   return kvm

--- a/src/routes/amt/setAMTFeatures.ts
+++ b/src/routes/amt/setAMTFeatures.ts
@@ -27,8 +27,9 @@ export async function setAMTFeatures (req: Request, res: Response): Promise<void
     let redir = amtRedirectionResponse.AMT_RedirectionService.ListenerEnabled
     let sol = (amtRedirectionResponse.AMT_RedirectionService.EnabledState & Common.Models.AMT_REDIRECTION_SERVICE_ENABLE_STATE.Enabled) !== 0
     let ider = (amtRedirectionResponse.AMT_RedirectionService.EnabledState & Common.Models.AMT_REDIRECTION_SERVICE_ENABLE_STATE.Other) !== 0
-    let kvm = (kvmRedirectionResponse.CIM_KVMRedirectionSAP.EnabledState === Common.Models.CIM_KVM_REDIRECTION_SAP_ENABLED_STATE.Enabled ||
-      kvmRedirectionResponse.CIM_KVMRedirectionSAP.EnabledState === Common.Models.CIM_KVM_REDIRECTION_SAP_ENABLED_STATE.EnabledButOffline)
+    let kvm = (kvmRedirectionResponse.CIM_KVMRedirectionSAP != null &&
+      (kvmRedirectionResponse.CIM_KVMRedirectionSAP.EnabledState === Common.Models.CIM_KVM_REDIRECTION_SAP_ENABLED_STATE.Enabled ||
+       kvmRedirectionResponse.CIM_KVMRedirectionSAP.EnabledState === Common.Models.CIM_KVM_REDIRECTION_SAP_ENABLED_STATE.EnabledButOffline))
 
     if (payload.enableSOL !== sol) {
       sol = payload.enableSOL


### PR DESCRIPTION
## PR Checklist

N/A

## What are you changing?

On some devices, CIM_KVMRedirectionSAP isn't returned.  This adds a check that it's actually present before using it.

See issue #668 for details.
