### PR TITLE
fix: issue #661 - don't try to access a zero length body

### DIFF
--- a/src/utils/parseWSManResponseBody.test.ts
+++ b/src/utils/parseWSManResponseBody.test.ts
@@ -48,7 +48,7 @@ describe('Check parseWSManResponseBody', () => {
     expect(response).toEqual(generalSettings)
   })
 
-  it('Should fail and return null when a message does not contain \r\n', async () => {
+  it('Should fail and return an empty response when a message does not contain \r\n', async () => {
     const xmlResponse: HttpZResponseModel = {
       protocolVersion: 'HTTP/1.1',
       statusCode: 200,
@@ -75,6 +75,35 @@ describe('Check parseWSManResponseBody', () => {
         text: '<?xml version="1.0" encoding="UTF-8"?><a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://intel.com/wbem/wscim/1/amt-schema/1/AMT_GeneralSettings" xmlns:xsi="http://www.w3.org/2001/XMLSchema-ins'
       }
     }
+    const response = parseBody(xmlResponse)
+    expect(response).toBe('')
+  })
+
+  it('Should fail and return an empty response when there is no message body', async () => {
+    // See issue #661; this response is documented there.
+    const xmlResponse: HttpZResponseModel = {
+      protocolVersion: 'HTTP/1.1',
+      statusCode: 400,
+      statusMessage: 'Bad Request',
+      headersSize: 143,
+      bodySize: 0,
+      headers: [
+        {
+          name: 'Date',
+          value: 'Mon, 1 Aug 2022 18:54:20 GMT'
+        },
+        {
+          name: 'Server',
+          value: 'Intel(R) Active Management Technology 15.0.41.2142'
+        },
+        {
+          name: 'Content-Length',
+          value: '0'
+        }
+      ],
+      body: null
+    }
+    delete xmlResponse.body // Yes, really!  It's not there in this case.
     const response = parseBody(xmlResponse)
     expect(response).toBe('')
   })

--- a/src/utils/parseWSManResponseBody.ts
+++ b/src/utils/parseWSManResponseBody.ts
@@ -7,6 +7,8 @@ import { HttpZResponseModel } from 'http-z'
 
 export function parseBody (message: HttpZResponseModel): string {
   let xmlBody: string = ''
+  // 'Bad' requests to some devices return no body (issue #661) - prevent exceptions below
+  if (message.bodySize === 0) return ''
   // parse the body until its length is greater than 5, because body ends with '0\r\n\r\n'
   while (message.body.text.length > 5) {
     const chunkLength = message.body.text.indexOf('\r\n')


### PR DESCRIPTION
## PR Checklist

- [x] Unit Tests have been added for new changes
- [x] All commented code has been removed

## What are you changing?

Fix for issue #661.

## Anything the reviewer should know when reviewing this PR?

See discussion for issue #661.  The test uses the exact message that caused the problem.  Note that in spite of 'body' not being optional in HttpZResponseModel, it wasn't present in this case.

Also fixed text for the previous last test, the return is an empty string, not null.