### PR TITLE
fix: InstanceID and ElementName shouldn't be treated as numeric if th…

### DIFF
--- a/src/amt/HttpHandler.ts
+++ b/src/amt/HttpHandler.ts
@@ -19,6 +19,15 @@ export class connectionParams {
   digestChallenge?: DigestChallenge
 }
 
+function myParseNumbers (value: string, name: string): any {
+  if (name === 'ElementName' || name === 'InstanceID') {
+    if (value.length > 1 && value.charAt(0) === '0') {
+      return value
+    }
+  }
+  return xml2js.processors.parseNumbers(value, name)
+}
+
 export class HttpHandler {
   digestChallenge: any
   authResolve: any
@@ -30,7 +39,7 @@ export class HttpHandler {
   parser: any
   constructor () {
     this.stripPrefix = xml2js.processors.stripPrefix
-    this.parser = new xml2js.Parser({ ignoreAttrs: true, mergeAttrs: false, explicitArray: false, tagNameProcessors: [this.stripPrefix], valueProcessors: [xml2js.processors.parseNumbers, xml2js.processors.parseBooleans] })
+    this.parser = new xml2js.Parser({ ignoreAttrs: true, mergeAttrs: false, explicitArray: false, tagNameProcessors: [this.stripPrefix], valueProcessors: [myParseNumbers, xml2js.processors.parseBooleans] })
   }
 
   wrapIt (connectionParams: connectionParams, data: string): string {

--- a/src/amt/httpHandler.test.ts
+++ b/src/amt/httpHandler.test.ts
@@ -19,6 +19,20 @@ it('should throw an error and return null when it parse invalid xml', async () =
   const result = httpHandler.parseXML(xml)
   expect(result).toBe(null)
 })
+it('should preserve leading zeros in ElementName and InstanceID', async () => {
+  const xml: string = '<?xml version="1.0" encoding="UTF-8"?><a:Envelope xmlns:a="http://www.w3.org/2003/05/soap-envelope" xmlns:b="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:c="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:d="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:e="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:f="http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd" xmlns:g="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:h="http://intel.com/wbem/wscim/1/ips-schema/1/IPS_AlarmClockOccurrence" xmlns:i="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><a:Header><b:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</b:To><b:RelatesTo>1</b:RelatesTo><b:Action a:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</b:Action><b:MessageID>uuid:00000000-8086-8086-8086-0000000022AF</b:MessageID><c:ResourceURI>http://intel.com/wbem/wscim/1/ips-schema/1/IPS_AlarmClockOccurrence</c:ResourceURI></a:Header><a:Body><g:PullResponse><g:Items><h:IPS_AlarmClockOccurrence><h:DeleteOnCompletion>true</h:DeleteOnCompletion><h:ElementName>01</h:ElementName><h:InstanceID>01</h:InstanceID><h:StartTime><i:Datetime>2022-11-30T18:51:00Z</i:Datetime></h:StartTime></h:IPS_AlarmClockOccurrence></g:Items><g:EndOfSequence></g:EndOfSequence></g:PullResponse></a:Body></a:Envelope>'
+  const result = httpHandler.parseXML(xml)
+  const expected = {
+    DeleteOnCompletion: true,
+    ElementName: '01',
+    InstanceID: '01',
+    StartTime: {
+      Datetime: '2022-11-30T18:51:00Z'
+    }
+  }
+  expect(result?.Envelope?.Body?.PullResponse?.Items?.IPS_AlarmClockOccurrence).toEqual(expected)
+})
+
 it('should parse authentication response header with 1 comma in value', async () => {
   const digestChallenge = {
     realm: 'Digest:56ABC7BE224EF620C69EB88F01071DC8',


### PR DESCRIPTION
## PR Checklist

- [x] Unit Tests have been added for new changes
- [x] All commented code has been removed

## What are you changing?

Fix as discussed in issue #735.

## Anything the reviewer should know when reviewing this PR?

The ```if (value.length > 1 && value.charAt(0) === '0')``` test probably isn't necessary if we are certain ElementName and InstanceID are always strings.

```myParseNumbers``` could easily be extended to either select just tags that should be treated as numbers, or to add other tags that should not be treated as numbers.