### PR TITLE
fix: issue #743 - close channel on Request 'aborted' event

### DIFF
--- a/src/server/webserver.test.ts
+++ b/src/server/webserver.test.ts
@@ -210,7 +210,8 @@ describe('webserver tests', () => {
           ciraHandler: {
             channel: 2
           }
-        }
+        },
+        on: jest.fn()
       }
       const res: Express.Response = {
         on: jest.fn()
@@ -231,14 +232,22 @@ describe('webserver tests', () => {
               CloseChannel: jest.fn()
             }
           }
-        }
+        },
+        on: jest.fn(),
+        removeListener: jest.fn()
       }
       const res: Express.Response = {
         removeListener: jest.fn()
       }
       const afterResponseSpy = jest.spyOn(web, 'afterResponse')
+      const closeChannelSpy = jest.spyOn((req as any).deviceAction.ciraHandler.channel, 'CloseChannel')
+      const reqRemoveListenerSpy = jest.spyOn(req as any, 'removeListener')
+      const resRemoveListenerSpy = jest.spyOn(res as any, 'removeListener')
       web.afterResponse(req as any, res as any)
       expect(afterResponseSpy).toHaveBeenCalledTimes(1)
+      expect(closeChannelSpy).toHaveBeenCalledTimes(1)
+      expect(reqRemoveListenerSpy).toHaveBeenCalledTimes(1)
+      expect(resRemoveListenerSpy).toHaveBeenCalledTimes(2)
     })
     it('test afterResponse with undefined channel', () => {
       const req: Express.Request = {
@@ -246,7 +255,9 @@ describe('webserver tests', () => {
           ciraHandler: {
             channel: null
           }
-        }
+        },
+        on: jest.fn(),
+        removeListener: jest.fn()
       }
       const res: Express.Response = {
         removeListener: jest.fn()
@@ -254,6 +265,23 @@ describe('webserver tests', () => {
       const afterResponseSpy = jest.spyOn(web, 'afterResponse')
       web.afterResponse(req as any, res as any)
       expect(afterResponseSpy).toHaveBeenCalledTimes(2)
+    })
+    it('test onAborted calls afterResponse', () => {
+      const req: Express.Request = {
+        deviceAction: {
+          ciraHandler: {
+            channel: null
+          }
+        },
+        on: jest.fn(),
+        removeListener: jest.fn()
+      }
+      const res: Express.Response = {
+        removeListener: jest.fn()
+      }
+      const afterResponseSpy = jest.spyOn(web, 'afterResponse')
+      web.onAborted(req as any, res as any)
+      expect(afterResponseSpy).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/src/server/webserver.ts
+++ b/src/server/webserver.ts
@@ -81,7 +81,13 @@ export class WebServer {
   appUseCall (req: Request, res: Response, next: NextFunction): void {
     res.on('finish', this.afterResponse.bind(this, req, res))
     res.on('close', this.afterResponse.bind(this, req, res))
+    req.on('aborted', this.onAborted.bind(this, req, res))
     next()
+  }
+
+  onAborted (req: Request, res: Response): void {
+    logger.debug(`Request aborted: ${req.url ?? 'undefined'}`)
+    this.afterResponse(req, res)
   }
 
   afterResponse (req: Request, res: Response): void {
@@ -91,6 +97,7 @@ export class WebServer {
     }
     res.removeListener('finish', this.afterResponse)
     res.removeListener('close', this.afterResponse)
+    req.removeListener('aborted', this.onAborted)
     // actions after response
   }
 


### PR DESCRIPTION
## PR Checklist

- [x] Unit Tests have been added for new changes

## What are you changing?

Ensure that the channel is closed if an API request is aborted (for example: back, reload etc. in the browser with the sample UI).

## Anything the reviewer should know when reviewing this PR?

This is a placeholder really.  See the issue for details about a 'better' fix to avoid the potentially moving target of which events are emitted by which object and when.

Note that the aborted event seems to be deprecated with later versions of nodejs.  They suggest using 'close' instead, but that is called for every request.  If that is the case, then it alone could be used and there would be no need to listen for 'finish' or 'close' on the response.

The unit tests have been improved test to ensure CloseChannel is called and listeners removed after a request 'completes'.
