### PR TITLE
fix: issue #741 - don't send CHANNEL_CLOSE more than once

### DIFF
--- a/src/amt/APFProcessor.test.ts
+++ b/src/amt/APFProcessor.test.ts
@@ -197,6 +197,7 @@ describe('APFProcessor Tests', () => {
     it('should return 9 + LengthOfData if cirachannel is null', () => {
       const fakeCiraSocket = {
         tag: {
+          activetunnels: 0,
           channels: []
         }
       }
@@ -223,6 +224,7 @@ describe('APFProcessor Tests', () => {
       } as any
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 1,
           channels: [null, fakeCiraChannel]
         }
       } as any
@@ -248,6 +250,7 @@ describe('APFProcessor Tests', () => {
     it('should return 9 if cirachannel is null', () => {
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 0,
           channels: [null, null]
         }
       } as any
@@ -269,6 +272,7 @@ describe('APFProcessor Tests', () => {
       } as any
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 1,
           channels: [fakeCiraChannel]
         }
       } as any
@@ -296,6 +300,7 @@ describe('APFProcessor Tests', () => {
       } as any
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 1,
           channels: [fakeCiraChannel]
         }
       } as any
@@ -323,6 +328,7 @@ describe('APFProcessor Tests', () => {
     it('should return 5 if cirachannel is null', () => {
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 0,
           channels: [null, null]
         }
       } as any
@@ -344,6 +350,7 @@ describe('APFProcessor Tests', () => {
       } as any
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 1,
           channels: [null, fakeCiraChannel]
         }
       } as any
@@ -352,13 +359,14 @@ describe('APFProcessor Tests', () => {
       const result = APFProcessor.channelClose(fakeCiraSocket, 5, '')
       expect(result).toEqual(5)
       expect(readIntSpy).toHaveBeenCalled()
-      expect(sendChannelCloseSpy).toHaveBeenCalled()
+      expect(sendChannelCloseSpy).toHaveBeenCalledWith(fakeCiraChannel)
     })
   })
 
   describe('channelOpenFailure() tests', () => {
     const fakeCiraSocket: CIRASocket = {
       tag: {
+        activetunnels: 0,
         channels: []
       }
     } as any
@@ -387,6 +395,7 @@ describe('APFProcessor Tests', () => {
       } as any
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 0,
           channels: [null, fakeCiraChannel]
         }
       } as any
@@ -413,6 +422,7 @@ describe('APFProcessor Tests', () => {
       } as any
       fakeCiraSocket = {
         tag: {
+          activetunnels: 1,
           channels: [null, fakeCiraChannel]
         }
       } as any
@@ -430,6 +440,7 @@ describe('APFProcessor Tests', () => {
     it('should return 17 if cirachannel is null', () => {
       const fakeCiraSocket: CIRASocket = {
         tag: {
+          activetunnels: 0,
           channels: []
         }
       } as any
@@ -600,6 +611,7 @@ describe('APFProcessor Tests', () => {
     } as any
     const fakeCiraSocket: CIRASocket = {
       tag: {
+        activetunnels: 1,
         channels: [null, fakeCiraChannel]
       }
     } as any
@@ -1132,7 +1144,11 @@ describe('APFProcessor Tests', () => {
     })
 
     it('should SendChannelClose', () => {
-      APFProcessor.SendChannelClose(fakeCiraSocket, channelid)
+      const fakeCiraChannel: CIRAChannel = {
+        socket: fakeCiraSocket,
+        amtchannelid: channelid
+      } as any
+      APFProcessor.SendChannelClose(fakeCiraChannel)
       const dataExpected = String.fromCharCode(APFProtocol.CHANNEL_CLOSE) + Common.IntToStr(channelid)
       expect(writeSpy).toHaveBeenCalledWith(fakeCiraSocket, dataExpected)
     })

--- a/src/amt/APFProcessor.ts
+++ b/src/amt/APFProcessor.ts
@@ -172,7 +172,7 @@ const APFProcessor = {
       logger.error(`${messages.CHANNEL_CLOSE_NO_CHANNEL_ID} ${RecipientChannel}`)
       return 5
     }
-    APFProcessor.SendChannelClose(cirachannel.socket, cirachannel.amtchannelid)
+    APFProcessor.SendChannelClose(cirachannel)
     socket.tag.activetunnels--
     if (cirachannel.state > 0) {
       cirachannel.state = 0
@@ -219,7 +219,7 @@ const APFProcessor = {
     logger.silly(`${messages.MPS_CHANNEL_OPEN_CONFIRMATION}, ${recipientChannel.toString()}, ${senderChannel.toString()}, ${windowSize.toString()}`)
     if (cirachannel.closing === 1) {
       // Close this channel
-      APFProcessor.SendChannelClose(cirachannel.socket, cirachannel.amtchannelid)
+      APFProcessor.SendChannelClose(cirachannel)
     } else {
       cirachannel.state = 2
       // Send any pending data
@@ -509,9 +509,15 @@ const APFProcessor = {
     )
   },
 
-  SendChannelClose: (socket: CIRASocket, channelid): void => {
-    logger.silly(`${messages.MPS_SEND_CHANNEL_CLOSE}, ${channelid}`)
-    APFProcessor.Write(socket, String.fromCharCode(APFProtocol.CHANNEL_CLOSE) + Common.IntToStr(channelid))
+  SendChannelClose: (cirachannel: CIRAChannel): void => {
+    if (!cirachannel.closeSent) {
+      cirachannel.closeSent = true
+      logger.silly(`${messages.MPS_SEND_CHANNEL_CLOSE}, ${cirachannel.amtchannelid}`)
+      APFProcessor.Write(
+        cirachannel.socket,
+        String.fromCharCode(APFProtocol.CHANNEL_CLOSE) + Common.IntToStr(cirachannel.amtchannelid)
+      )
+    }
   },
 
   SendPendingData: (cirachannel: CIRAChannel): void => {

--- a/src/amt/CIRAChannel.test.ts
+++ b/src/amt/CIRAChannel.test.ts
@@ -58,7 +58,7 @@ describe('CIRA Channel', () => {
     ciraChannel.amtchannelid = 44
     const sendChannelSpy = jest.spyOn(APFProcessor, 'SendChannelClose').mockImplementation(() => {})
     const state = ciraChannel.CloseChannel()
-    expect(sendChannelSpy).toHaveBeenCalledWith(socket, 44)
+    expect(sendChannelSpy).toHaveBeenCalledWith(ciraChannel)
     expect(state).toBe(0)
   })
   it('should write data to channel', async () => {


### PR DESCRIPTION
## PR Checklist

- [x] API tests have been updated if applicable

## What are you changing?

Fix for issue #741.

Check/set new CIRAChannel.closeSent boolean in APFProcessor.SendChannelClose().

## Anything the reviewer should know when reviewing this PR?

APFProcessorSendChannelClose() needs knowledge of the CIRAChannel object so now takes it as a parameter.
