### PR TITLE
refactor(db): align variable names for limit and offset

### DIFF
--- a/src/data/postgres/tables/device.ts
+++ b/src/data/postgres/tables/device.ts
@@ -32,7 +32,7 @@ export class DeviceTable implements IDeviceTable {
    * @description Get all devices from DB
    * @returns {Device[]} returns an array of objects
    */
-  async get (top: number = DefaultTop, skip: number = DefaultSkip, tenantId: string = ''): Promise<Device[]> {
+  async get (limit: number = DefaultTop, offset: number = DefaultSkip, tenantId: string = ''): Promise<Device[]> {
     const results = await this.db.query<Device>(`
     SELECT 
       guid as "guid",
@@ -47,7 +47,7 @@ export class DeviceTable implements IDeviceTable {
     FROM devices
     WHERE tenantid = $3 
     ORDER BY guid 
-    LIMIT $1 OFFSET $2`, [top, skip, tenantId])
+    LIMIT $1 OFFSET $2`, [limit, offset, tenantId])
     return results.rows
   }
 

--- a/src/interfaces/IDeviceTable.ts
+++ b/src/interfaces/IDeviceTable.ts
@@ -9,7 +9,7 @@ import { type ITable } from './ITable'
 export interface IDeviceTable extends ITable<Device> {
   getConnectedDevices: (tenantId?: string) => Promise<number>
   getDistinctTags: (tenantId?: string) => Promise<string[]>
-  getByTags: (tags: string[], method: string, top: number, skip: number, tenantId?: string) => Promise<Device[]>
+  getByTags: (tags: string[], method: string, limit: number | string, offset: number | string, tenantId?: string) => Promise<Device[]>
   getByFriendlyName: (hostname: string, tenantId?: string) => Promise<Device[]>
   getByHostname: (hostname: string, tenantId?: string) => Promise<Device[]>
   clearInstanceStatus: (mpsInstance: string, tenantId?: string) => Promise<boolean>

--- a/src/interfaces/ITable.ts
+++ b/src/interfaces/ITable.ts
@@ -5,7 +5,7 @@
 
 export interface ITable<T> {
   getCount: (tenantId?: string) => Promise<number>
-  get: (limit: number, offset: number, tenantId?: string) => Promise<T[]>
+  get: (limit: number | string, offset: number | string, tenantId?: string) => Promise<T[]>
   getById: (id: string, tenantId?: string) => Promise<T>
   delete: (name: string, tenantId?: string) => Promise<boolean>
   insert: (item: T) => Promise<T>


### PR DESCRIPTION
This is not a breaking change despite the variable names changing in the interface/implementation as typescript doesn't enforce the parameter names.

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?
<!-- Please provide a short description of the updates that are in the PR -->


## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )
