### PR TITLE
fix: update legacy cipher setting

### DIFF
--- a/src/utils/certificates.ts
+++ b/src/utils/certificates.ts
@@ -48,7 +48,7 @@ export class Certificates {
       'DHE-RSA-AES256-GCM-SHA384',
       'TLS_AES_256_GCM_SHA384',
       'TLS_AES_128_GCM_SHA256'].join(':')
-    const legacySupportCiphers = 'HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA'
+    const legacySupportCiphers = 'HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA:@SECLEVEL=0'
     let mpsConfig: mpsConfigType
     if (this.config.mps_tls_config.minVersion === 'TLSv1.2' || this.config.mps_tls_config.minVersion === 'TLSv1.3') {
       mpsConfig = { cert: mpsCertificate, key: mpsPrivateKey, minVersion: this.config.mps_tls_config.minVersion, requestCert: true, rejectUnauthorized: false, ciphers: secureCiphers }


### PR DESCRIPTION
- allow legacy cipher when MPS runs with backward compatibility

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.


## What are you changing?
Allow legacy cipher to be enabled when using Node JS version > 16.


## Anything the reviewer should know when reviewing this PR?
Due to the nature of the changes, test is performed on an actual deployment.

Tested using 
```
curl -k --tls-max 1.0 --ciphers 'AES128-SHA:AES256-SHA' https://mpshost:4433/
```
Tested using real hardware (NUC5i5MHYE-Broadwell) by:
- manually updating MPSCerts ciphers in vault and reload mps service
- new stack deployment with updated mps code
CIRA on AMT 10 could connect on both cases.

### If the there are associated PRs in other repositories, please link them here (i.e. open-amt-cloud-toolkit/repo#365 )
