### PR TITLE
fix: Override OpenSSL security level to allow TLSv1 connections

### DIFF
--- a/src/utils/certificates.ts
+++ b/src/utils/certificates.ts
@@ -67,7 +67,7 @@ export class Certificates {
       'TLS_AES_256_GCM_SHA384',
       'TLS_AES_128_GCM_SHA256'
     ].join(':')
-    const legacySupportCiphers = 'HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA'
+    const legacySupportCiphers = 'HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA:@SECLEVEL=0'
     let mpsConfig: mpsConfigType
     if (this.config.mps_tls_config.minVersion === 'TLSv1.2' || this.config.mps_tls_config.minVersion === 'TLSv1.3') {
       mpsConfig = {


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] ~~Unit Tests have been added for new changes~~ no code changes
- [ ] API tests have been updated if applicable
- [ ] ~~All commented code has been removed~~ no code changes
- [ ] ~~If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.~~ no dependency changes

## What are you changing?

OpenSSL's default security level in Alpine prevents TLSv1 and TLSv1.1 connections from being made to TLS endpoints by default. In order to still support the legacy versions of AMT, this PR changes the default cipher string to also set the security level to 0.

## Anything the reviewer should know when reviewing this PR?

I haven't added any unit tests as no real code has changed, just the cipher list.
