### PR TITLE
fix: loosens UUID check for API

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -13,6 +13,6 @@ import { authorizeDevice } from './authorizeDevice.js'
 const authRouter: Router = Router()
 
 authRouter.post('/', authValidator(), login)
-authRouter.get('/redirection/:guid', param('guid').isUUID(), validateMiddleware, authorizeDevice)
+authRouter.get('/redirection/:guid', param('guid').isUUID('loose'), validateMiddleware, authorizeDevice)
 
 export default authRouter

--- a/src/routes/devices/deviceValidator.ts
+++ b/src/routes/devices/deviceValidator.ts
@@ -6,7 +6,7 @@
 import { check, query } from 'express-validator'
 
 export const validator = (): any => [
-  check('guid').isUUID().isString(),
+  check('guid').isUUID('loose').isString(),
   check('friendlyName').optional({ nullable: true }).isString(),
   check('hostname')
     .optional({ nullable: true })

--- a/src/routes/devices/index.ts
+++ b/src/routes/devices/index.ts
@@ -24,17 +24,17 @@ const deviceRouter: Router = Router()
 deviceRouter.get('/', odataValidator(), metadataQueryValidator(), validateMiddleware, getAllDevices)
 deviceRouter.get('/stats', stats)
 deviceRouter.get('/tags', getDistinctTags)
-deviceRouter.get('/:guid', param('guid').isUUID(), validateMiddleware, getDevice)
-deviceRouter.get('/redirectstatus/:guid', param('guid').isUUID(), validateMiddleware, ciraMiddleware, getRedirStatus)
+deviceRouter.get('/:guid', param('guid').isUUID('loose'), validateMiddleware, getDevice)
+deviceRouter.get('/redirectstatus/:guid', param('guid').isUUID('loose'), validateMiddleware, ciraMiddleware, getRedirStatus)
 deviceRouter.post('/', validator(), validateMiddleware, insertDevice)
 deviceRouter.patch('/', validator(), validateMiddleware, updateDevice)
 deviceRouter.delete('/refresh/:guid', validator(), validateMiddleware, refreshDevice)
 deviceRouter.delete(
   '/:guid',
-  param('guid').isUUID(),
+  param('guid').isUUID('loose'),
   query('isSecretToBeDeleted').optional().isBoolean(),
   validateMiddleware,
   deleteDevice
 )
-deviceRouter.delete('/disconnect/:guid', param('guid').isUUID(), validateMiddleware, ciraMiddleware, disconnect)
+deviceRouter.delete('/disconnect/:guid', param('guid').isUUID('loose'), validateMiddleware, ciraMiddleware, disconnect)
 export default deviceRouter


### PR DESCRIPTION
Not all device ids are following RFC 4122, this should allow non-compliant UUIDs.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
