### PR TITLE
fix: get WiFi eth by InstanceID instead of PhysicalConnectionType

### DIFF
--- a/src/amt/DeviceAction.ts
+++ b/src/amt/DeviceAction.ts
@@ -725,11 +725,8 @@ export class DeviceAction {
 
       const ports = Array.isArray(settings) ? settings : [settings]
 
-      // Find the first port with PhysicalConnectionType = 3 (Wireless LAN)
-      const wifiPort = ports.find((port: any) => {
-        const connectionType = parseInt(port.PhysicalConnectionType, 10)
-        return connectionType === 3
-      })
+      // Find the WiFi port by InstanceID (Intel(r) AMT Ethernet Port Settings 1)
+      const wifiPort = ports.find((port: any) => port.InstanceID === 'Intel(r) AMT Ethernet Port Settings 1')
 
       if (wifiPort == null) {
         logger.error('findWiFiPort: No WiFi port found')
@@ -757,7 +754,7 @@ export class DeviceAction {
     const wifiPortInfo = await this.findWiFiPort()
     if (wifiPortInfo == null) {
       const errorMsg =
-        'No WiFi port found on this device. SetLinkPreference requires a WiFi interface (PhysicalConnectionType=3).'
+        'No WiFi port found on this device. SetLinkPreference requires the WiFi InstanceID "Intel(r) AMT Ethernet Port Settings 1".'
       logger.error(`setEthernetLinkPreference: ${errorMsg}`)
       return null
     }

--- a/src/amt/deviceAction.test.ts
+++ b/src/amt/deviceAction.test.ts
@@ -663,11 +663,10 @@ describe('Device Action Tests', () => {
       expect(result).not.toBeNull()
       expect(result?.instanceID).toBe('Intel(r) AMT Ethernet Port Settings 1')
       expect(result?.settings.InstanceID).toBe('Intel(r) AMT Ethernet Port Settings 1')
-      expect(result?.settings.PhysicalConnectionType).toBe('3')
       expect(result?.settings.ElementName).toBe('WiFi Port')
     })
 
-    it('should return null when no WiFi port exists', async () => {
+    it('should return null when no WiFi port exists for findWiFiPort', async () => {
       const mockEnumResponse = {
         Body: {
           PullResponse: {
@@ -678,7 +677,7 @@ describe('Device Action Tests', () => {
                   PhysicalConnectionType: '0' // Only LAN
                 },
                 {
-                  InstanceID: 'Intel(r) AMT Ethernet Port Settings 1',
+                  InstanceID: 'Intel(r) AMT Ethernet Port Settings 2',
                   PhysicalConnectionType: '1' // Only LAN
                 }
               ]
@@ -720,7 +719,7 @@ describe('Device Action Tests', () => {
       expect(getSpy).toHaveBeenCalled()
     })
 
-    it('should return null when no WiFi port found', async () => {
+    it('should return null when no WiFi port found for setEthernetLinkPreference', async () => {
       const mockEnumResponse = {
         Body: {
           PullResponse: {


### PR DESCRIPTION
- PhysicalConnectionType is only introduced since AMT 15. 
- Use InstanceID for backward compatibility with AMT 14 and prior.

- API test:
  - Set LinkPreference to 1 (ME):
    - <img width="1497" height="465" alt="image" src="https://github.com/user-attachments/assets/8f6bd38b-d802-49f3-8d36-df677d77839a" />
  - Set LinkPreference to 2 (Host): 
    - <img width="1494" height="488" alt="image" src="https://github.com/user-attachments/assets/b7cee719-12ff-4434-a2d7-03621d210375" />

---

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
