### PR TITLE
fix: added input validator for dnsSuffix

### DIFF
--- a/src/routes/devices/deviceValidator.test.ts
+++ b/src/routes/devices/deviceValidator.test.ts
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Copyright (c) Intel Corporation 2026
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+import { validationResult } from 'express-validator'
+import { describe, expect, it } from '@jest/globals'
+import { validator } from './deviceValidator.js'
+
+async function getValidationErrors(body: any): Promise<any[]> {
+  const req: any = { body, query: {}, params: {} }
+  const chains = validator()
+
+  for (const chain of chains) {
+    await chain.run(req)
+  }
+
+  return validationResult(req).array()
+}
+
+describe('device validator dnsSuffix checks', () => {
+  it('accepts a valid dnsSuffix', async () => {
+    const errors = await getValidationErrors({
+      guid: '123e4567-e89b-12d3-a456-426614174000',
+      dnsSuffix: 'os.suffix.com'
+    })
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('accepts null dnsSuffix', async () => {
+    const errors = await getValidationErrors({
+      guid: '123e4567-e89b-12d3-a456-426614174000',
+      dnsSuffix: null
+    })
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it("accepts empty string dnsSuffix", async () => {
+    const errors = await getValidationErrors({
+      guid: '123e4567-e89b-12d3-a456-426614174000',
+      dnsSuffix: ''
+    })
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('rejects dnsSuffix containing query string characters', async () => {
+    const errors = await getValidationErrors({
+      guid: '123e4567-e89b-12d3-a456-426614174000',
+      dnsSuffix: 'None?injected_query_string=123'
+    })
+
+    expect(errors.some((error) => error.path === 'dnsSuffix')).toBeTruthy()
+    const dnsSuffixError = errors.find((error) => error.path === 'dnsSuffix')
+    expect(dnsSuffixError).toBeDefined()
+    expect(dnsSuffixError?.msg).toContain('dnsSuffix')
+  })
+})

--- a/src/routes/devices/deviceValidator.ts
+++ b/src/routes/devices/deviceValidator.ts
@@ -13,6 +13,16 @@ export const validator = (): any => [
     .isString()
     .isLength({ max: 255 })
     .withMessage('Hostname must be less than 256 characters'),
+  check('dnsSuffix')
+    .optional({ nullable: true })
+    .isString()
+    .bail()
+    .isLength({ max: 255 })
+    .withMessage('dnsSuffix must be less than 256 characters')
+    .bail()
+    .if((value) => value !== '')
+    .isFQDN({ require_tld: false, allow_trailing_dot: true })
+    .withMessage('dnsSuffix must be a valid DNS suffix'),
   check('mpsusername').optional({ nullable: true }).isString(),
   check('connect').optional({ nullable: true }).isISO8601().toDate(),
   check('disconnect').optional({ nullable: true }).isISO8601().toDate(),

--- a/src/test/collections/MPS.postman_collection.json
+++ b/src/test/collections/MPS.postman_collection.json
@@ -501,6 +501,99 @@
           "response": []
         },
         {
+          "name": "Create Device with invalid dnsSuffix query injection",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 400\", function () {\r",
+                  "    pm.response.to.have.status(400);\r",
+                  "});\r",
+                  "pm.test(\"Expect dnsSuffix validation error\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.errors[0].path).to.be.equal(\"dnsSuffix\");\r",
+                  "    pm.expect(jsonData.errors[0].msg).to.be.equal(\"dnsSuffix must be a valid DNS suffix\");\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n    \"guid\": \"143e4567-e89b-12d3-a456-426614174009\",\r\n    \"friendlyName\": \"friendlyName\",\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": [],\r\n    \"mpsusername\": \"admin\",\r\n    \"dnsSuffix\": \"None?injected_query_string=123\"\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Device with non-string dnsSuffix",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 400\", function () {\r",
+                  "    pm.response.to.have.status(400);\r",
+                  "});\r",
+                  "pm.test(\"Expect dnsSuffix type validation error\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.errors[0].path).to.be.equal(\"dnsSuffix\");\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n    \"guid\": \"143e4567-e89b-12d3-a456-426614174010\",\r\n    \"friendlyName\": \"friendlyName\",\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": [],\r\n    \"mpsusername\": \"admin\",\r\n    \"dnsSuffix\": {}\r\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Device by GUID",
           "event": [
             {
@@ -756,6 +849,100 @@
           "response": []
         },
         {
+          "name": "Update Device with invalid dnsSuffix query injection",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 400\", function () {\r",
+                  "    pm.response.to.have.status(400);\r",
+                  "});\r",
+                  "pm.test(\"Expect dnsSuffix validation error\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.errors[0].path).to.be.equal(\"dnsSuffix\");\r",
+                  "    pm.expect(jsonData.errors[0].msg).to.be.equal(\"dnsSuffix must be a valid DNS suffix\");\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n        \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n        \"hostname\": \"hostname\",\r\n        \"dnsSuffix\": \"None?injected_query_string=123\",\r\n        \"tags\": [\"acm\"]\r\n    }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Device with invalid dnsSuffix length",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 400\", function () {\r",
+                  "    pm.response.to.have.status(400);\r",
+                  "});\r",
+                  "pm.test(\"Expect dnsSuffix length validation error\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.errors[0].path).to.be.equal(\"dnsSuffix\");\r",
+                  "    pm.expect(jsonData.errors[0].msg).to.be.equal(\"dnsSuffix must be less than 256 characters\");\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n        \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n        \"hostname\": \"hostname\",\r\n        \"dnsSuffix\": \"zaZswmJkhAIkIw7f8zFjSlvbv78Ua61Vlgz2JToGRZYo2nXIlKG7ck8ZjoHjudSe95WVwQVDdMuLA7mVRIek7okrHGaaElLXfFzX7zp2buylQGpzQueCmMmi3usHQPXqAwGJNexRcUQyBqTDqbv5PM5bLlylv3S0esWclfYoAahFXvtcgjmJw8r1fGIOzGWjGKWkzbP1vYObDctXhJdg7fk6tnfEdnnUkKo9953I5NjT0amWVIhqo8nwQPIO14gb44wyQAgpsJkT8xJNXNGSb63RmMbynIpfXpIbIWWuhLtrnyQyOTYJ9FHO8R4jARTZqtzyfyNToMUjajQ4ytMtcpLCvyiVxQJ3XiBaUo8nFEZK2tglcRQUWhdOauKOM68ttbhBNogQPFimq05c64Xo7YicxJb7PGEgUTbYv5vnmuekDIIibj3iQIL6pRGwymg5NkXlPKXz7SBhqiGXUNArXPPIXKqxts3SMBEgDKvF94e6XYXmiNZga64qZs0aLnNbOgBexjuDONG0ziQw5yav7DZwLemgyuIOoqbhx3lzaKAuyqzlS54waVCHOYGAickj6JbtzZzHqueWETJfqtWv7XQGQvg1C7TJAQpvtY6gbvQBV8PPiKMmbQ9Om1tvYX52aoKo0TU6R7CiG6MtgihSuA8uOvxABhNIg89rvWFJVUqEY21XObwRpdKV9TBbQ3GIftKXuZKImRiA216m4Dk368wn5S5T9TY5A5z7HNavratpgp1nR9aSilt42fWfw92gJAP1I53kdmFR0TOLOyPZ1SPeuCtmxZq6aASUaheJfyrgxBJveuRaGb1mHfHX4W3aXd19SLTf1foqQyxFU00rdfhUfUaQpNVOebx4CqDYmh4ABtp1XpS4z8fZ0prqiYRWNqfqWbHtruKkj0UwpK5WBNwRGbP2Ejsl0TsshB8U6e54Yh18TFv2LufbRsitC0DhZPH3zydRM6azBzcYcNtAZmFqLHPfNPe80XWF4jU8dO8iI3qnSX6OdYrIS8IiFIUlId9bHkrypqtE7mkc4WZjBPGTm3KLKBakDfKlQzOqhPZnc1UVXz6YU64JdKEbtYM5UlSc1s8cUg1YFInwjyiNEwv768wfk1vj7nIzixWH1agANzrY0OiTLTTIxZ56snlQ7oBHzIwK8V7AjmoVnI5Ao38eZ8swlnVBtw49tqqW4lguZ06AccYxkrg4AFmGp61SITfw2Xtxia6lXlCHlriaw0nAyFncu8JCsSjMEeFuaBmgQIyR2wG3qBEwIW2zrVRqBpGmeqfsut5Vq4DaDfr7G9BuopVK1D13ePev\",\r\n        \"tags\": [\"acm\"]\r\n    }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Update Device not found",
           "event": [
             {
@@ -834,6 +1021,194 @@
             "body": {
               "mode": "raw",
               "raw": "{\r\n        \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n        \"hostname\": \"hostname\",\r\n        \"dnsSuffix\": \"os.suffix.com\",\r\n        \"tags\": [\"acm\"]\r\n    }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Device with empty dnsSuffix",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
+                  "});\r",
+                  "pm.test(\"Expect empty dnsSuffix is accepted\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.guid).to.be.equal(\"143e4567-e89b-12d3-a456-426614174000\");\r",
+                  "    pm.expect(jsonData.dnsSuffix).to.be.equal(\"\");\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n        \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n        \"hostname\": \"hostname\",\r\n        \"dnsSuffix\": \"\",\r\n        \"tags\": [\"acm\"]\r\n    }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Device with null dnsSuffix",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
+                  "});\r",
+                  "pm.test(\"Expect null dnsSuffix is accepted\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.guid).to.be.equal(\"143e4567-e89b-12d3-a456-426614174000\");\r",
+                  "    pm.expect(jsonData.dnsSuffix).to.be.equal(null);\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n        \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n        \"hostname\": \"hostname\",\r\n        \"dnsSuffix\": null,\r\n        \"tags\": [\"acm\"]\r\n    }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Device with trailing-dot dnsSuffix",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
+                  "});\r",
+                  "pm.test(\"Expect trailing-dot dnsSuffix is accepted\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.guid).to.be.equal(\"143e4567-e89b-12d3-a456-426614174000\");\r",
+                  "    pm.expect(jsonData.dnsSuffix).to.be.equal(\"os.suffix.com.\");\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n        \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n        \"hostname\": \"hostname\",\r\n        \"dnsSuffix\": \"os.suffix.com.\",\r\n        \"tags\": [\"acm\"]\r\n    }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}/api/v1/devices",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "devices"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Device with single-label dnsSuffix",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {\r",
+                  "    pm.response.to.have.status(200);\r",
+                  "});\r",
+                  "pm.test(\"Expect single-label dnsSuffix is accepted\",function(){\r",
+                  "    var jsonData = pm.response.json();\r",
+                  "    pm.expect(jsonData.guid).to.be.equal(\"143e4567-e89b-12d3-a456-426614174000\");\r",
+                  "    pm.expect(jsonData.dnsSuffix).to.be.equal(\"localdomain\");\r",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n        \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n        \"hostname\": \"hostname\",\r\n        \"dnsSuffix\": \"localdomain\",\r\n        \"tags\": [\"acm\"]\r\n    }",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [x] Unit Tests have been added for new changes
- [x] API tests have been updated if applicable
- [x] All commented code has been removed
- [x] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

- added input validator for dnsSuffix
- added unit test for dnsSuffix validator
- added MPS API postman tests as follow
  1. Create Device with invalid dnsSuffix query injection (negative, expect 400)
  2. Create Device with non-string dnsSuffix (negative, expect 400)
  3. Update Device with invalid dnsSuffix query injection (negative, expect 400)
  4. Update Device with invalid dnsSuffix length (negative, expect 400)
  5. Update Device with empty dnsSuffix (positive, expect 200)
  6. Update Device with null dnsSuffix (positive, expect 200)
  7. Update Device with trailing-dot dnsSuffix (positive, expect 200)
  8. Update Device with single-label dnsSuffix (positive, expect 200)

## Anything the reviewer should know when reviewing this PR?

- PR to fix #2389 

### Testing

MPS return 400 instead of 200

```
2026-03-18 06:28:16.093: Sending: 'PATCH /api/v1/devices HTTP/1.1\r\nAccept: application/json\r\nHost: device-management-toolkit-mps-1:3000\r\nContent-Type: application/json\r\nContent-Length: 199\r\nUser-Agent: restler/9.3.1\r\nx-restler-sequence-id: 11d6f8b6-09dc-48e0-8dee-87825e9e6897\r\n\r\n{\n    "guid":"123e4567-e89b-12d3-a456-426614174000",\n    "hostname":"AMTDEVICENUC1",\n    "dnsSuffix":"None?injected_query_string=123",\n    "friendlyName":"store12pos2",\n    "tags":["tag1", "tag2"]}\r\n'

2026-03-18 06:28:16.096: Received: 'HTTP/1.1 400 Bad Request\r\nX-Powered-By: Express\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: 152\r\nETag: W/"98-PoDfLW3A8aDc5CvA9FUeIGklUPY"\r\nDate: Wed, 18 Mar 2026 06:28:16 GMT\r\nConnection: keep-alive\r\nKeep-Alive: timeout=5\r\n\r\n{"errors":[{"type":"field","value":"None?injected_query_string=123","msg":"dnsSuffix must be a valid DNS suffix","path":"dnsSuffix","location":"body"}]}'
```

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )