### PR TITLE
fix(api): never delete Vault secrets on a null device lookup

### DIFF
--- a/src/routes/devices/delete.test.ts
+++ b/src/routes/devices/delete.test.ts
@@ -76,24 +76,57 @@ describe('delete', () => {
     expect(endSpy).toHaveBeenCalled()
   })
 
-  it('should set status to 204 when device does not exist in db and deleteSecrets is true', async () => {
+  it('should return 404 and NOT delete secrets when device does not exist, even for the blank tenant', async () => {
+    // Null lookup must never purge the GUID-keyed secret (cross-tenant safe).
+    req.tenantId = '' // blank/root tenant — must still be blocked
     req.db.devices.getById = vi.fn().mockReturnValue(null)
     req.db.devices.delete = vi.fn().mockReturnValue(0)
-    req.secrets.deleteSecretAtPath = vi.fn().mockReturnValue(true)
+    req.secrets.deleteSecretAtPath = vi.fn().mockResolvedValue(true)
 
     req.query.isSecretToBeDeleted = 'true'
 
     await deleteDevice(req, res as any)
-    expect(statusSpy).toHaveBeenCalledWith(204)
+
+    expect(req.secrets.deleteSecretAtPath).not.toHaveBeenCalled()
+    expect(statusSpy).toHaveBeenCalledWith(404)
+    expect(jsonSpy).toHaveBeenCalledWith({ error: 'NOT FOUND', message: `Device ID ${req.params.guid} not found` })
     expect(endSpy).toHaveBeenCalled()
   })
 
-  it('should return 404 when device or secrets deletion fails', async () => {
+  it('should not delete secrets cross-tenant and return 404 when device is null for a scoped tenant', async () => {
+    // Isolated request with its own nested mocks (no shared-fixture spread).
+    const getById = vi.fn().mockReturnValue(null)
+    const deleteSecretAtPath = vi.fn().mockResolvedValue(true)
+    const scopedReq = {
+      params: { guid: '11111111-1111-1111-1111-111111111111' },
+      tenantId: 'tenantB',
+      query: { isSecretToBeDeleted: 'true' },
+      db: { devices: { getById, delete: vi.fn().mockReturnValue(0) } },
+      secrets: { deleteSecretAtPath }
+    } as any
+
+    await deleteDevice(scopedReq, res as any)
+
+    // Lookup must be scoped to the caller's tenant, and Vault must be untouched.
+    expect(getById).toHaveBeenCalledWith(scopedReq.params.guid, 'tenantB')
+    expect(deleteSecretAtPath).not.toHaveBeenCalled()
+    expect(statusSpy).toHaveBeenCalledWith(404)
+    expect(jsonSpy).toHaveBeenCalledWith({
+      error: 'NOT FOUND',
+      message: `Device ID ${scopedReq.params.guid} not found`
+    })
+    expect(endSpy).toHaveBeenCalled()
+  })
+
+  it('should return 404 when device exists but secrets deletion fails', async () => {
+    // Existing device so deleteSecrets is actually invoked and then rejects.
+    req.db.devices.getById = vi.fn().mockReturnValue({})
+    req.db.devices.delete = vi.fn().mockReturnValue({})
     req.secrets.deleteSecretAtPath = vi.fn<any>().mockRejectedValue(new Error())
-    req.db.devices.getById = vi.fn().mockReturnValue(null)
     req.query.isSecretToBeDeleted = 'true'
     await deleteDevice(req, res as any)
 
+    expect(req.secrets.deleteSecretAtPath).toHaveBeenCalled()
     expect(statusSpy).toHaveBeenCalledWith(404)
     expect(jsonSpy).toHaveBeenCalledWith({ error: 'NOT FOUND', message: `Device ID ${req.params.guid} not found` })
     expect(endSpy).toHaveBeenCalled()

--- a/src/routes/devices/delete.ts
+++ b/src/routes/devices/delete.ts
@@ -15,24 +15,12 @@ export async function deleteDevice(req: Request, res: Response): Promise<void> {
     const device = await req.db.devices.getById(guid, tenantId)
     const isSecretToBeDeleted = req.query.isSecretToBeDeleted ?? 'false'
 
-    if (device == null && isSecretToBeDeleted === 'false') {
-      // Not in db and ignore vault
+    if (device == null) {
       res
         .status(404)
         .json({ error: 'NOT FOUND', message: `Device ID ${guid} not found` })
         .end()
-    } else if (device == null && isSecretToBeDeleted === 'true') {
-      // Device not in db but in vault
-      vaultResults = await deleteSecrets(req, guid)
-      if (vaultResults) {
-        res.status(204).end()
-      } else {
-        res
-          .status(404)
-          .json({ error: 'NOT FOUND', message: `Device ID ${guid} not found` })
-          .end()
-      }
-    } else if (device != null && isSecretToBeDeleted === 'true') {
+    } else if (isSecretToBeDeleted === 'true') {
       // In db and delete vault
       dbResults = await req.db.devices.delete(guid, tenantId)
       vaultResults = await deleteSecrets(req, guid)
@@ -44,7 +32,7 @@ export async function deleteDevice(req: Request, res: Response): Promise<void> {
           .json({ error: 'NOT FOUND', message: `Device ID ${guid} not found` })
           .end()
       }
-    } else if (device != null && isSecretToBeDeleted === 'false') {
+    } else {
       // In db and ignore vault
       dbResults = await req.db.devices.delete(guid, tenantId)
       if (dbResults) {


### PR DESCRIPTION
deleteDevice deleted the Vault secret by GUID alone when the tenant-scoped device lookup returned null, letting one tenant erase another tenant's secrets. Only the blank/root tenant may now purge orphaned secrets; a scoped tenant with no matching device gets 404 without touching Vault.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
