### PR TITLE
build(deps): add overrides to patch brace-expansion DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1796,9 +1796,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2783,9 +2783,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -80,5 +80,11 @@
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"
+  },
+  "overrides": {
+    "brace-expansion": "5.0.7",
+    "filelist": {
+      "brace-expansion": "2.1.2"
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

## Summary

Fixes Dependabot alert `brace-expansion` DoS vulnerability

## Why Dependabot couldn't auto-fix

Two separate vulnerable paths exist, neither resolvable via normal version bumps:

| Path | Vulnerable version | Fix |
|---|---|---|
| `eslint` / `typescript-eslint` → `brace-expansion` | `5.0.6` | `5.0.7` |
| `genversion` → `ejs` → `jake` → `filelist` → `minimatch@5.1.9` → `brace-expansion` | `2.1.0` | `2.1.2` |

For the 2.x path, `genversion@3.2.0` is already the latest version and
`minimatch@5.1.9` has no patch that bumps `brace-expansion` above `2.1.2`.

## Fix

Added `overrides` to `package.json`:

```json
"overrides": {
  "brace-expansion": "5.0.7",
  "filelist": {
    "brace-expansion": "2.1.2"
  }
}
