### PR TITLE
ci(gh-actions): resolve zizmor findings

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -19,6 +19,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - run: docker build -f Dockerfile -t mps:${GITHUB_SHA} .
       - run: docker compose up -d
       - run: sleep 30

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,6 +30,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Docker Login
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -38,5 +40,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           logout: true
       - name: Build and Push the Docker image
-        run: docker buildx build --platform linux/amd64,linux/arm64 --push . --file Dockerfile --tag ${{ github.event.inputs.docker_registry }}/${{ github.event.inputs.docker_tag_name }}
+        env:
+          DOCKER_REGISTRY: ${{ github.event.inputs.docker_registry }}
+          DOCKER_TAG_NAME: ${{ github.event.inputs.docker_tag_name }}
+        run: docker buildx build --platform linux/amd64,linux/arm64 --push . --file Dockerfile --tag "$DOCKER_REGISTRY/$DOCKER_TAG_NAME"
      

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,6 +33,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: .github/commitlint.config.cjs

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -22,6 +22,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build the Docker image
 
         run: docker build . --file Dockerfile --tag vprodemo.azurecr.io/mps:${{ github.sha }} --tag vprodemo.azurecr.io/mps:latest

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+# Zizmor configuration. See https://docs.zizmor.sh/configuration/
+rules:
+  # Daily updates with no cooldown are intentional here. A version compromised
+  # at publish time can reach CI before it is yanked, but the blast radius is
+  # small: Dependabot PRs do not receive repository secrets by default and run
+  # with a read-only GITHUB_TOKEN.
+  dependabot-cooldown:
+    ignore:
+      - dependabot.yml


### PR DESCRIPTION
- Set persist-credentials: false on actions/checkout in api-test, codeql-analysis, docker-image, node.js, semantic and trivy-scan workflows; none of these jobs push back to git.
- Move the docker_registry / docker_tag_name inputs out of the docker-image build run block into step-level env vars, referenced as quoted shell variables, to avoid template injection.
- Add .github/zizmor.yml ignoring dependabot-cooldown, with a note on why daily uncooled updates are acceptable here.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
